### PR TITLE
fix: logs folder

### DIFF
--- a/custom_components/byd_battery_box/bydboxclient.py
+++ b/custom_components/byd_battery_box/bydboxclient.py
@@ -68,7 +68,7 @@ class BydBoxClient(ExtModbusClient):
 
         self.data['unit_id'] = unit_id
 
-        self._log_path = './custom_components/byd_battery_box/log/'
+        self._log_path = './custom_components/byd_battery_box/logs/'
         self._log_csv_path = self._log_path + 'byd_log.csv'
         self._log_txt_path = self._log_path + 'byd.log'
         self._log_json_path = self._log_path + 'byd_log.json'

--- a/custom_components/byd_battery_box/bydboxclient.py
+++ b/custom_components/byd_battery_box/bydboxclient.py
@@ -72,43 +72,39 @@ class BydBoxClient(ExtModbusClient):
         self._log_txt_path = self._log_path + 'byd.log'
         self._log_json_path = self._log_path + 'byd_log.json'
 
-    def toggle_busy(func):
-        async def wrapper(self, *args, **kwargs):
-            if self.busy:
-                _LOGGER.debug(f"skip {func.__name__} client busy") 
-                return False
-            self.busy = True
-            error = None
-            try:
-                result = await func(self, *args, **kwargs)
-            except Exception as e:
-                _LOGGER.warning(f'Exception in wrapper {e}')
-                error = e
-            self.busy = False
-            if not error is None:
-                raise error
-            return result
-        return wrapper
+    class ClientBusyLock:
+        """Async context manager for managing client busy state."""
 
-    @toggle_busy
+        def __init__(self, client):
+            self.client = client
+
+        async def __aenter__(self):
+            while self.client.busy:
+                await asyncio.sleep(0.1)
+            self.client.busy = True
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            self.client.busy = False
+
     async def init_data(self, close = False) -> bool:
+        async with self.ClientBusyLock(self):
+            if not self._client.connected: await self._client.connect()
 
-        if not self._client.connected: await self._client.connect() 
+            try:
+                await self.update_info_data()
+            except Exception as e:
+                raise Exception(f"Error reading base info unit id: {self._unit_id}")
 
-        try:
-            await self.update_info_data()
-        except Exception as e:
-            raise Exception(f"Error reading base info unit id: {self._unit_id}")
+            try:
+                await self.update_ext_info_data()
+            except Exception as e:
+                raise Exception(f"Error reading ext info unit id: {self._unit_id}")
 
-        try:
-            await self.update_ext_info_data()
-        except Exception as e:
-            raise Exception(f"Error reading ext info unit id: {self._unit_id}")
-
-        self.initialized = True
-        if close: self.close()
-        _LOGGER.debug(f"init done.")          
-        return True
+            self.initialized = True
+            if close: self.close()
+            _LOGGER.debug(f"init done.")
+            return True
 
     def update_log_from_file(self) -> bool:
         if not os.path.exists(self._log_path):
@@ -146,40 +142,40 @@ class BydBoxClient(ExtModbusClient):
         
         return False
 
-    @toggle_busy
     async def update_all_bms_status_data(self) -> bool:
-        for bms_id in range(1, self._bms_qty + 1):
-            if bms_id > 0:
-                await asyncio.sleep(.2)
-            try:
-                result = await self.update_bms_status_data(bms_id)
-            except Exception as e:
-                _LOGGER.error(f"Error reading BMS status data {bms_id}", exc_info=True)
-                return False
-            if not result:
-                #_LOGGER.debug(f"Failed updating data BMS status data {bms_id}", exc_info=True)
-                return False
-        return True   
+        async with self.ClientBusyLock(self):
+            for bms_id in range(1, self._bms_qty + 1):
+                if bms_id > 0:
+                    await asyncio.sleep(.2)
+                try:
+                    result = await self.update_bms_status_data(bms_id)
+                except Exception as e:
+                    _LOGGER.error(f"Error reading BMS status data {bms_id}", exc_info=True)
+                    return False
+                if not result:
+                    #_LOGGER.debug(f"Failed updating data BMS status data {bms_id}", exc_info=True)
+                    return False
+            return True
 
-    @toggle_busy
     async def update_all_log_data(self) -> bool:
-        result = False
-        self._new_logs = {}
-        for device_id in range(self._bms_qty + 1):
-            if device_id > 0:
-                await asyncio.sleep(.2)
-            try:
-                result = await self.update_log_data(device_id)
-            except Exception as e:
-                _LOGGER.error(f"Unknown error reading log {self._get_device_name(device_id)} data", exc_info=True)
-            if not result:
-                _LOGGER.debug(f'Failed update log {self._get_device_name(device_id)} data')
-                return False
+        async with self.ClientBusyLock(self):
+            result = False
+            self._new_logs = {}
+            for device_id in range(self._bms_qty + 1):
+                if device_id > 0:
+                    await asyncio.sleep(.2)
+                try:
+                    result = await self.update_log_data(device_id)
+                except Exception as e:
+                    _LOGGER.error(f"Unknown error reading log {self._get_device_name(device_id)} data", exc_info=True)
+                if not result:
+                    _LOGGER.debug(f'Failed update log {self._get_device_name(device_id)} data')
+                    return False
 
-        self.data[f'log'] = self.get_log_list(20)
-        self._update_balancing_cells_totals()
-        self.data['log_entries'] = len(self.log)    
-        return True
+            self.data[f'log'] = self.get_log_list(20)
+            self._update_balancing_cells_totals()
+            self.data['log_entries'] = len(self.log)
+            return True
 
     def _update_balancing_cells_totals(self) -> None:
         try:
@@ -352,55 +348,55 @@ class BydBoxClient(ExtModbusClient):
 
         return True
 
-    @toggle_busy
     async def update_bmu_status_data(self) -> bool:
         """start reading bmu status data"""
-        regs = await self.get_registers(address=0x0500, count=21) # 1280
-        if regs is None:
-            _LOGGER.warning('update_bmu_status_data regs is None')
-            return False
+        async with self.ClientBusyLock(self):
+            regs = await self.get_registers(address=0x0500, count=21) # 1280
+            if regs is None:
+                _LOGGER.warning('update_bmu_status_data regs is None')
+                return False
 
-        soc = self._client.convert_from_registers(regs[0:1], data_type = self._client.DATATYPE.UINT16)
-        max_cell_voltage = round(self._client.convert_from_registers(regs[1:2], data_type = self._client.DATATYPE.UINT16) * 0.01,2)
-        min_cell_voltage = round(self._client.convert_from_registers(regs[2:3], data_type = self._client.DATATYPE.UINT16) * 0.01,2)
-        soh = self._client.convert_from_registers(regs[3:4], data_type = self._client.DATATYPE.UINT16)
-        current = round(self._client.convert_from_registers(regs[4:5], data_type = self._client.DATATYPE.INT16) * 0.1,1)
-        bat_voltage = round(self._client.convert_from_registers(regs[5:6], data_type = self._client.DATATYPE.UINT16) * 0.01,2)
-        max_cell_temp = self._client.convert_from_registers(regs[6:7], data_type = self._client.DATATYPE.INT16)
-        min_cell_temp = self._client.convert_from_registers(regs[7:8], data_type = self._client.DATATYPE.INT16)
-        bmu_temp = self._client.convert_from_registers(regs[8:9], data_type = self._client.DATATYPE.INT16)
-        # 9-12 ?
-        if regs[9:13] != [0, 792, 0, 0]:
-            _LOGGER.debug(f'bmu status reg 9-12: {regs[9:13]} [0, 792, 0, 0]')
-        errors = self._client.convert_from_registers(regs[13:14], data_type = self._client.DATATYPE.UINT16)
-        param_t_v1, param_t_v2 = self.convert_from_registers_int8(regs[14:15]) 
-        output_voltage = round(self._client.convert_from_registers(regs[16:17], data_type = self._client.DATATYPE.UINT16) * 0.01,2)
-        # TODO: change to use standard pymodbus function once HA has been upgraded to later version
-        charge_lfte = self.convert_from_registers(regs[17:19], data_type = self._client.DATATYPE.UINT32, word_order='little') * 0.1
-        discharge_lfte = self.convert_from_registers(regs[19:21], data_type = self._client.DATATYPE.UINT32, word_order='little') * 0.1
+            soc = self._client.convert_from_registers(regs[0:1], data_type = self._client.DATATYPE.UINT16)
+            max_cell_voltage = round(self._client.convert_from_registers(regs[1:2], data_type = self._client.DATATYPE.UINT16) * 0.01,2)
+            min_cell_voltage = round(self._client.convert_from_registers(regs[2:3], data_type = self._client.DATATYPE.UINT16) * 0.01,2)
+            soh = self._client.convert_from_registers(regs[3:4], data_type = self._client.DATATYPE.UINT16)
+            current = round(self._client.convert_from_registers(regs[4:5], data_type = self._client.DATATYPE.INT16) * 0.1,1)
+            bat_voltage = round(self._client.convert_from_registers(regs[5:6], data_type = self._client.DATATYPE.UINT16) * 0.01,2)
+            max_cell_temp = self._client.convert_from_registers(regs[6:7], data_type = self._client.DATATYPE.INT16)
+            min_cell_temp = self._client.convert_from_registers(regs[7:8], data_type = self._client.DATATYPE.INT16)
+            bmu_temp = self._client.convert_from_registers(regs[8:9], data_type = self._client.DATATYPE.INT16)
+            # 9-12 ?
+            if regs[9:13] != [0, 792, 0, 0]:
+                _LOGGER.debug(f'bmu status reg 9-12: {regs[9:13]} [0, 792, 0, 0]')
+            errors = self._client.convert_from_registers(regs[13:14], data_type = self._client.DATATYPE.UINT16)
+            param_t_v1, param_t_v2 = self.convert_from_registers_int8(regs[14:15])
+            output_voltage = round(self._client.convert_from_registers(regs[16:17], data_type = self._client.DATATYPE.UINT16) * 0.01,2)
+            # TODO: change to use standard pymodbus function once HA has been upgraded to later version
+            charge_lfte = self.convert_from_registers(regs[17:19], data_type = self._client.DATATYPE.UINT32, word_order='little') * 0.1
+            discharge_lfte = self.convert_from_registers(regs[19:21], data_type = self._client.DATATYPE.UINT32, word_order='little') * 0.1
 
-        param_t_v = f"{param_t_v1}.{param_t_v2}"
-        efficiency = round((discharge_lfte / charge_lfte) * 100.0,1)
+            param_t_v = f"{param_t_v1}.{param_t_v2}"
+            efficiency = round((discharge_lfte / charge_lfte) * 100.0,1)
 
-        self.data['soc'] = soc
-        self.data['max_cell_v'] = max_cell_voltage
-        self.data['min_cell_v'] = min_cell_voltage
-        self.data['soh'] = soh
-        self.data['current'] = current
-        self.data['bat_voltage'] = bat_voltage
-        self.data['max_cell_temp'] = max_cell_temp
-        self.data['min_cell_temp'] = min_cell_temp
-        self.data['bmu_temp'] = bmu_temp
-        self.data['errors'] =  self.bitmask_to_string(errors, BMU_ERRORS, 'Normal')    
-        self.data['param_t_v'] = param_t_v
-        self.data['output_voltage'] = output_voltage
-        self.data['power'] = current * output_voltage
-        self.data['charge_lfte'] = charge_lfte
-        self.data['discharge_lfte'] = discharge_lfte
-        self.data['efficiency'] = efficiency
-        self.data[f'updated'] = datetime.now()
+            self.data['soc'] = soc
+            self.data['max_cell_v'] = max_cell_voltage
+            self.data['min_cell_v'] = min_cell_voltage
+            self.data['soh'] = soh
+            self.data['current'] = current
+            self.data['bat_voltage'] = bat_voltage
+            self.data['max_cell_temp'] = max_cell_temp
+            self.data['min_cell_temp'] = min_cell_temp
+            self.data['bmu_temp'] = bmu_temp
+            self.data['errors'] =  self.bitmask_to_string(errors, BMU_ERRORS, 'Normal')
+            self.data['param_t_v'] = param_t_v
+            self.data['output_voltage'] = output_voltage
+            self.data['power'] = current * output_voltage
+            self.data['charge_lfte'] = charge_lfte
+            self.data['discharge_lfte'] = discharge_lfte
+            self.data['efficiency'] = efficiency
+            self.data[f'updated'] = datetime.now()
 
-        return True
+            return True
        
     async def update_bms_status_data(self, bms_id) -> bool:
         """start reading status data"""

--- a/custom_components/byd_battery_box/bydboxclient.py
+++ b/custom_components/byd_battery_box/bydboxclient.py
@@ -10,6 +10,7 @@ import binascii
 import json
 import csv
 import os
+import time
 from .extmodbusclient import ExtModbusClient
 
 from .bydbox_const import (
@@ -72,6 +73,25 @@ class BydBoxClient(ExtModbusClient):
         self._log_txt_path = self._log_path + 'byd.log'
         self._log_json_path = self._log_path + 'byd_log.json'
 
+        # Initialize connection health monitor
+        self.health_monitor = self.ConnectionHealthMonitor(self)
+
+    def get_connection_metrics(self):
+        """Return current connection health data for HA sensor."""
+        # Note: This is called synchronously, so we return current state without running async health check
+        health_status = (self.health_monitor.last_success is not None and
+                        self.health_monitor.consecutive_failures < 3 and
+                        (self.health_monitor.last_latency is None or self.health_monitor.last_latency < 5.0))
+
+        return {
+            'connection_quality': round(self.health_monitor.connection_quality * 100, 1),
+            'last_latency': round(self.health_monitor.last_latency, 3) if self.health_monitor.last_latency else None,
+            'avg_latency': round(self.health_monitor.avg_latency, 3) if self.health_monitor.avg_latency else None,
+            'consecutive_failures': self.health_monitor.consecutive_failures,
+            'last_success': self.health_monitor.last_success.isoformat() if self.health_monitor.last_success else None,
+            'connection_health': 'healthy' if health_status else 'unhealthy'
+        }
+
     class ClientBusyLock:
         """Async context manager for managing client busy state."""
 
@@ -86,6 +106,75 @@ class BydBoxClient(ExtModbusClient):
 
         async def __aexit__(self, exc_type, exc_val, exc_tb):
             self.client.busy = False
+
+    class ConnectionHealthMonitor:
+        """Monitors connection health metrics and quality."""
+
+        def __init__(self, client, update_interval=60):
+            self.client = client
+            self.last_latency = None
+            self.avg_latency = None
+            self.connection_quality = 1.0  # 0.0 to 1.0
+            self.last_success = None
+            self.consecutive_failures = 0
+            self.update_interval = update_interval
+            self._monitor_task = None
+
+        async def measure_latency(self) -> Optional[float]:
+            start = time.perf_counter()
+            try:
+                # Quick, low-impact register read for measurement
+                result = await self.client.read_holding_registers(
+                    unit_id=self.client._unit_id,
+                    address=0x0000,  # Basic info register - low impact
+                    count=1
+                )
+                if result:
+                    latency = time.perf_counter() - start
+                    self.last_latency = latency
+
+                    # Update rolling average
+                    if self.avg_latency is None:
+                        self.avg_latency = latency
+                    else:
+                        self.avg_latency = (self.avg_latency * 0.8) + (latency * 0.2)
+
+                    # Calculate quality score (inverse relationship with latency)
+                    self.connection_quality = max(0.0, min(1.0, 2.0 / (1.0 + latency)))
+
+                    self.last_success = datetime.now()
+                    self.consecutive_failures = 0
+                    return latency
+            except Exception as e:
+                self.consecutive_failures += 1
+                _LOGGER.debug(f"Latency measurement failed: {e}")
+
+            return None
+
+        async def health_check(self) -> bool:
+            latency = await self.measure_latency()
+            # Consider healthy if latency < 5s and not too many consecutive failures
+            return (latency is not None and latency < 5.0 and
+                    self.consecutive_failures < 3)
+
+        async def periodic_health_update(self):
+            """Run health checks periodically"""
+            while True:
+                await self.measure_latency()
+                await asyncio.sleep(self.update_interval)
+
+        def start_monitoring(self):
+            """Start the background monitoring task"""
+            if self._monitor_task is None or self._monitor_task.done():
+                self._monitor_task = asyncio.create_task(self.periodic_health_update())
+                _LOGGER.debug("Connection health monitoring started")
+
+        def stop_monitoring(self):
+            """Stop the background monitoring task"""
+            if self._monitor_task:
+                self._monitor_task.cancel()
+                self._monitor_task = None
+                _LOGGER.debug("Connection health monitoring stopped")
 
     async def init_data(self, close = False) -> bool:
         async with self.ClientBusyLock(self):

--- a/custom_components/byd_battery_box/const.py
+++ b/custom_components/byd_battery_box/const.py
@@ -96,3 +96,12 @@ BMS_SENSOR_TYPES = {
     "last_log": ["Last log", "last_log",None, None, None, None, EntityCategory.DIAGNOSTIC],
     "b_total": ["Balancing total", "b_total",None, None, None, None, None],
 }
+
+# Connection Health Monitoring Diagnostic Sensors
+CONNECTION_SENSOR_TYPES = {
+    "connection_quality": ["Connection Quality", "connection_quality", None, SensorStateClass.MEASUREMENT, "%", "mdi:connection", EntityCategory.DIAGNOSTIC],
+    "last_latency": ["Last Latency", "last_latency", None, None, "ms", "mdi:timer", EntityCategory.DIAGNOSTIC],
+    "avg_latency": ["Average Latency", "avg_latency", None, None, "ms", "mdi:timer", EntityCategory.DIAGNOSTIC],
+    "consecutive_failures": ["Consecutive Failures", "consecutive_failures", None, SensorStateClass.MEASUREMENT, None, "mdi:alert-circle", EntityCategory.DIAGNOSTIC],
+    "connection_health": ["Connection Health", "connection_health", None, None, None, "mdi:check-circle", EntityCategory.DIAGNOSTIC],
+}

--- a/custom_components/byd_battery_box/hub.py
+++ b/custom_components/byd_battery_box/hub.py
@@ -45,6 +45,21 @@ class Hub:
         self._busy = False
         self._update_log_history_depth = [0,0]
 
+    class BusyLock:
+        """Async context manager for managing busy state."""
+
+        def __init__(self, hub):
+            self.hub = hub
+
+        async def __aenter__(self):
+            while self.hub._busy:
+                await asyncio.sleep(0.1)
+            self.hub._busy = True
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            self.hub._busy = False
+
 
     @property
     def data(self):
@@ -97,30 +112,12 @@ class Hub:
             self._unsub_interval_method = None
             self.close()
 
-    def toggle_busy(func):
-        async def wrapper(self, *args, **kwargs):
-            if self._busy:
-                #_LOGGER.debug(f"skip {func.__name__} hub busy")
-                return
-            self._busy = True
-            error = None
-            try:
-                result = await func(self, *args, **kwargs)
-            except Exception as e:
-                _LOGGER.warning(f'Exception in wrapper {e}')
-                error = e
-            self._busy = False
-            if not error is None:
-                raise error
-            return result
-        return wrapper
-
-    @toggle_busy
     async def init_data(self, close = False):
-        await self._hass.async_add_executor_job(self.check_pymodbus_version)
-        await self._hass.async_add_executor_job(self._bydclient.update_log_from_file)
-        await self._bydclient.init_data(close = close)
-        self.update_entities()
+        async with self.BusyLock(self):
+            await self._hass.async_add_executor_job(self.check_pymodbus_version)
+            await self._hass.async_add_executor_job(self._bydclient.update_log_from_file)
+            await self._bydclient.init_data(close = close)
+            self.update_entities()
 
     def check_pymodbus_version(self):
         try:
@@ -140,7 +137,6 @@ class Hub:
             _LOGGER.error(f"Error checking pymodbus version: {e}")
             raise
 
-    @toggle_busy
     async def async_update_data(self, _now: Optional[int] = None) -> dict:
         """Time to update."""
         if not self._bydclient.initialized:
@@ -150,69 +146,70 @@ class Hub:
             #_LOGGER.debug(f"Skip update give system a break ;-)")
             return
 
-        # update log history
-        unit_id = self._update_log_history_depth[0]
-        log_depth = self._update_log_history_depth[1]
-        if self._update_log_history_depth[1] > 0:
-            prev_len_log = len(self._bydclient.log)
-            _LOGGER.warning(f"Started loading {DEVICE_TYPES[unit_id]} log history; all other data updates will be suspended!")
-            try:
-                await self._bydclient.update_log_data(unit_id, log_depth=log_depth)
-                self._last_log_update = datetime.now()
-                self._last_update = datetime.now()
-            except Exception as e:
-                _LOGGER.error(f'Failed updating {DEVICE_TYPES[unit_id]} log history {self._update_log_history_depth} {e}', exc_info=True)
-                return False
-            self._update_log_history_depth[1] = 0
-            if prev_len_log != len(self._bydclient.log):
-                result : bool = await self._hass.async_add_executor_job(self._bydclient.save_log_entries)
-            return True
-
-        # update last log data
-        if ((datetime.now()-self._last_log_update) > self._scan_interval_log):
-            #_LOGGER.debug(f"start update log data")
-            prev_len_log = len(self._bydclient.log)
-            result = await self._bydclient.update_all_log_data()
-            self._last_log_update = datetime.now()
-            self._last_update = datetime.now()
-            if result:
-                self.update_entities()
+        async with self.BusyLock(self):
+            # update log history
+            unit_id = self._update_log_history_depth[0]
+            log_depth = self._update_log_history_depth[1]
+            if self._update_log_history_depth[1] > 0:
+                prev_len_log = len(self._bydclient.log)
+                _LOGGER.warning(f"Started loading {DEVICE_TYPES[unit_id]} log history; all other data updates will be suspended!")
+                try:
+                    await self._bydclient.update_log_data(unit_id, log_depth=log_depth)
+                    self._last_log_update = datetime.now()
+                    self._last_update = datetime.now()
+                except Exception as e:
+                    _LOGGER.error(f'Failed updating {DEVICE_TYPES[unit_id]} log history {self._update_log_history_depth} {e}', exc_info=True)
+                    return False
+                self._update_log_history_depth[1] = 0
                 if prev_len_log != len(self._bydclient.log):
                     result : bool = await self._hass.async_add_executor_job(self._bydclient.save_log_entries)
-                _LOGGER.debug(f"updated log data")
-            else:
-                _LOGGER.error(f"update log data failed")
-                await asyncio.sleep(5)
+                return True
 
-        # update bms data
-        if ((datetime.now()-self._last_full_update) > self._scan_interval_bms):
-            #_LOGGER.debug(f"start update BMS status")
-            result = await self._bydclient.update_all_bms_status_data()
+            # update last log data
+            if ((datetime.now()-self._last_log_update) > self._scan_interval_log):
+                #_LOGGER.debug(f"start update log data")
+                prev_len_log = len(self._bydclient.log)
+                result = await self._bydclient.update_all_log_data()
+                self._last_log_update = datetime.now()
+                self._last_update = datetime.now()
+                if result:
+                    self.update_entities()
+                    if prev_len_log != len(self._bydclient.log):
+                        result : bool = await self._hass.async_add_executor_job(self._bydclient.save_log_entries)
+                    _LOGGER.debug(f"updated log data")
+                else:
+                    _LOGGER.error(f"update log data failed")
+                    await asyncio.sleep(5)
+
+            # update bms data
+            if ((datetime.now()-self._last_full_update) > self._scan_interval_bms):
+                #_LOGGER.debug(f"start update BMS status")
+                result = await self._bydclient.update_all_bms_status_data()
+                if result:
+                    self._last_full_update = datetime.now()
+                    self._last_update = datetime.now()
+                    self.update_entities()
+                    _LOGGER.debug(f"updated BMS status")
+                else:
+                    _LOGGER.error(f"update BMS status data failed")
+                    await asyncio.sleep(5)
+
+            # update bmu
+            try:
+                #_LOGGER.debug(f"start update BMU status")
+                result = await self._bydclient.update_bmu_status_data()
+            except Exception as e:
+                _LOGGER.error(f"Error reading BMU status data connection {self._bydclient.connected} error: {e} ", exc_info=True)
+                return False
             if result:
-                self._last_full_update = datetime.now()
                 self._last_update = datetime.now()
                 self.update_entities()
-                _LOGGER.debug(f"updated BMS status")
+                _LOGGER.debug(f"updated BMU status")
             else:
-                _LOGGER.error(f"update BMS status data failed")
-                await asyncio.sleep(5)
+                _LOGGER.warning(f"update BMU status data failed {self._bydclient.connected}")
+                return False
 
-        # update bmu
-        try:
-            #_LOGGER.debug(f"start update BMU status")
-            result = await self._bydclient.update_bmu_status_data()
-        except Exception as e:
-            _LOGGER.error(f"Error reading BMU status data connection {self._bydclient.connected} error: {e} ", exc_info=True)
-            return False
-        if result:
-            self._last_update = datetime.now()
-            self.update_entities()
-            _LOGGER.debug(f"updated BMU status")
-        else:
-            _LOGGER.warning(f"update BMU status data failed {self._bydclient.connected}")
-            return False
-
-        return True
+            return True
 
     def update_entities(self):
         for update_callback in self._entities:

--- a/custom_components/byd_battery_box/hub.py
+++ b/custom_components/byd_battery_box/hub.py
@@ -117,6 +117,8 @@ class Hub:
             await self._hass.async_add_executor_job(self.check_pymodbus_version)
             await self._hass.async_add_executor_job(self._bydclient.update_log_from_file)
             await self._bydclient.init_data(close = close)
+            # Start connection health monitoring
+            self._bydclient.health_monitor.start_monitoring()
             self.update_entities()
 
     def check_pymodbus_version(self):

--- a/custom_components/byd_battery_box/sensor.py
+++ b/custom_components/byd_battery_box/sensor.py
@@ -19,6 +19,7 @@ from . import HubConfigEntry
 from .const import (
     BMU_SENSOR_TYPES,
     BMS_SENSOR_TYPES,
+    CONNECTION_SENSOR_TYPES,
     ENTITY_PREFIX,
 )
 from .hub import Hub
@@ -38,6 +39,22 @@ async def async_setup_entry(
 
     for sensor_info in BMU_SENSOR_TYPES.values():
         sensor = BydBoxSensor(
+            platform_name = ENTITY_PREFIX,
+            hub = hub,
+            device_info = hub.device_info_bmu,
+            name = sensor_info[0],
+            key = sensor_info[1],
+            device_class = sensor_info[2],
+            state_class = sensor_info[3],
+            unit = sensor_info[4],
+            icon = sensor_info[5],
+            entity_category = sensor_info[6],
+        )
+        entities.append(sensor)
+
+    # Add connection health monitoring sensors
+    for sensor_info in CONNECTION_SENSOR_TYPES.values():
+        sensor = BydBoxConnectionSensor(
             platform_name = ENTITY_PREFIX,
             hub = hub,
             device_info = hub.device_info_bmu,
@@ -184,6 +201,71 @@ class BydBoxSensor(SensorEntity, RestoreEntity):
             return {'cell_voltages': self._hub.data.get(f'{self._key}_cells')}
 
         return None
+
+    @property
+    def should_poll(self) -> bool:
+        """Data is delivered by the hub"""
+        return False
+
+    @property
+    def device_info(self) -> Optional[Dict[str, Any]]:
+        return self._device_info
+
+
+class BydBoxConnectionSensor(SensorEntity, RestoreEntity):
+    """Representation of a BYD Battery Box connection health sensor."""
+
+    def __init__(self, platform_name, hub, device_info, name, key, device_class, state_class, unit, icon, entity_category):
+        """Initialize the connection sensor."""
+        self._platform_name = platform_name
+        self._hub:Hub = hub
+        self._key = key
+        self._name = name
+        self._unit_of_measurement = unit
+        self._icon = icon
+        self._device_info = device_info
+        if not device_class is None:
+            self._attr_device_class = device_class
+        if not state_class is None:
+            self._attr_state_class = state_class
+        self._attr_entity_category = entity_category
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self._hub.async_add_hub_entity(self._connection_data_updated)
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._hub.async_remove_hub_entity(self._connection_data_updated)
+
+    @callback
+    def _connection_data_updated(self):
+        self.async_write_ha_state()
+
+    @property
+    def name(self):
+        """Return the name."""
+        return f"{self._name}"
+
+    @property
+    def unique_id(self) -> Optional[str]:
+        return f"{self._platform_name}_{self._key}"
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._unit_of_measurement
+
+    @property
+    def icon(self):
+        """Return the sensor icon."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the connection sensor."""
+        # Get connection metrics from the client
+        metrics = self._hub._bydclient.get_connection_metrics()
+        return metrics.get(self._key)
 
     @property
     def should_poll(self) -> bool:


### PR DESCRIPTION
Changes the log file directory path from `'log/'` to `'logs/'` to match the existing directory structure containing historical log data. This prevents creating duplicate log directories.

**Breaking: Could lead to history loss because of recreation of the log files (json & csv).**
