### PR TITLE
fix: close Modbus connection on init failure

### DIFF
--- a/custom_components/byd_battery_box/__init__.py
+++ b/custom_components/byd_battery_box/__init__.py
@@ -36,7 +36,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
     # with your actual devices.
     entry.runtime_data = hub.Hub(hass = hass, name = name, host = host, port = port, unit_id=unit_id, scan_interval = scan_interval, scan_interval_bms = scan_interval_bms, scan_interval_log=scan_interval_log)
 
-    await entry.runtime_data.init_data()
+    try:
+        await entry.runtime_data.init_data()
+    except Exception:
+        await entry.runtime_data.close()
+        raise
 
     # This creates each HA object for each platform your device requires.
     # It's done by calling the `async_setup_entry` function in each platform module.

--- a/custom_components/byd_battery_box/bydboxclient.py
+++ b/custom_components/byd_battery_box/bydboxclient.py
@@ -116,33 +116,40 @@ class BydBoxClient(ExtModbusClient):
             self._monitor_task = None
 
         async def measure_latency(self) -> float | None:
-            start = time.perf_counter()
-            try:
-                # Quick, low-impact register read for measurement
-                result = await self.client.read_holding_registers(
-                    unit_id=self.client._unit_id,
-                    address=0x0000,  # Basic info register - low impact
-                    count=1
-                )
-                if result:
-                    latency = time.perf_counter() - start
-                    self.last_latency = latency
+            # Skip if client is busy with a data update — health checks
+            # must not queue up behind real work or cause concurrent reads.
+            if self.client.busy:
+                _LOGGER.debug("Health check skipped, client busy")
+                return None
 
-                    # Update rolling average
-                    if self.avg_latency is None:
-                        self.avg_latency = latency
-                    else:
-                        self.avg_latency = (self.avg_latency * 0.8) + (latency * 0.2)
+            async with self.client.ClientBusyLock(self.client):
+                start = time.perf_counter()
+                try:
+                    # Quick, low-impact register read for measurement
+                    result = await self.client.read_holding_registers(
+                        unit_id=self.client._unit_id,
+                        address=0x0000,  # Basic info register - low impact
+                        count=1
+                    )
+                    if result:
+                        latency = time.perf_counter() - start
+                        self.last_latency = latency
 
-                    # Calculate quality score (inverse relationship with latency)
-                    self.connection_quality = max(0.0, min(1.0, 2.0 / (1.0 + latency)))
+                        # Update rolling average
+                        if self.avg_latency is None:
+                            self.avg_latency = latency
+                        else:
+                            self.avg_latency = (self.avg_latency * 0.8) + (latency * 0.2)
 
-                    self.last_success = datetime.now()
-                    self.consecutive_failures = 0
-                    return latency
-            except Exception as e:
-                self.consecutive_failures += 1
-                _LOGGER.debug(f"Latency measurement failed: {e}")
+                        # Calculate quality score (inverse relationship with latency)
+                        self.connection_quality = max(0.0, min(1.0, 2.0 / (1.0 + latency)))
+
+                        self.last_success = datetime.now()
+                        self.consecutive_failures = 0
+                        return latency
+                except Exception as e:
+                    self.consecutive_failures += 1
+                    _LOGGER.debug(f"Latency measurement failed: {e}")
 
             return None
 

--- a/custom_components/byd_battery_box/config_flow.py
+++ b/custom_components/byd_battery_box/config_flow.py
@@ -68,12 +68,14 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict[str, Any]:
     if data[CONF_LOG_SCAN_INTERVAL] < 120:
         raise LogScanIntervalTooShort
 
+    hub = Hub(hass, data[CONF_NAME], data[CONF_HOST], data[CONF_PORT], data[CONF_UNIT_ID], data[CONF_SCAN_INTERVAL], data[CONF_BMS_SCAN_INTERVAL], data[CONF_LOG_SCAN_INTERVAL])
     try:
-        hub = Hub(hass, data[CONF_NAME], data[CONF_HOST], data[CONF_PORT], data[CONF_UNIT_ID], data[CONF_SCAN_INTERVAL], data[CONF_BMS_SCAN_INTERVAL], data[CONF_LOG_SCAN_INTERVAL])
         await hub.init_data(close=True)
     except Exception as e:
-        # If there is an error, raise an exception to notify HA that there was a
-        # problem. The UI will also show there was a problem
+        # Ensure the Modbus connection is closed on failure.
+        # BYD batteries only allow one concurrent connection,
+        # so a leaked connection blocks all subsequent attempts.
+        await hub.close()
         _LOGGER.error(f"Cannot start hub {e}")
         raise CannotConnect
 

--- a/custom_components/byd_battery_box/hub.py
+++ b/custom_components/byd_battery_box/hub.py
@@ -111,6 +111,8 @@ class Hub:
             await self._hass.async_add_executor_job(self.check_pymodbus_version)
             await self._hass.async_add_executor_job(self._bydclient.update_log_from_file)
             await self._bydclient.init_data(close = close)
+            # Start connection health monitoring
+            self._bydclient.health_monitor.start_monitoring()
             self.update_entities()
 
     def check_pymodbus_version(self):

--- a/custom_components/byd_battery_box/hub.py
+++ b/custom_components/byd_battery_box/hub.py
@@ -111,8 +111,6 @@ class Hub:
             await self._hass.async_add_executor_job(self.check_pymodbus_version)
             await self._hass.async_add_executor_job(self._bydclient.update_log_from_file)
             await self._bydclient.init_data(close = close)
-            # Start connection health monitoring
-            self._bydclient.health_monitor.start_monitoring()
             self.update_entities()
 
     def check_pymodbus_version(self):


### PR DESCRIPTION
Below you can find the summary from claude code. This PR fixes an issue with this version of the integration. The upstream repo worked fine. When I switched to this one it never initialized because it could not connect to my battery. It seems that my version does not allow more than one modbus connection. The health monitor connection sometimes eats up the 1 available connection.

The error handling improvements ensure that the connection gets closed when this error occurs, this improved the testing a bit but never allowed the config flow to fully finish either.

The health monitor is now also behind the lock with an early exit when there is real work.

## Summary from claude

BYD batteries only allow a single concurrent Modbus TCP connection. When `init_data()` fails (e.g. transient network issue, timeout), the Modbus TCP connection is never closed. Home Assistant's automatic config entry retry then creates a new `Hub` instance, but the battery rejects the new connection because the previous one is still held. This creates a **permanent deadlock** that can only be resolved by restarting HA (and even then only if the retry doesn't fail again before the first successful read).

### Changes

- **`__init__.py`**: Wrap `init_data()` in try/except and call `hub.close()` on failure so the connection is released before HA retries
- **`config_flow.py`**: Same fix for `validate_input()` — close the hub when connection validation fails
- **`hub.py`**: Disable `ConnectionHealthMonitor.start_monitoring()` — it issues Modbus register reads every 60s **without acquiring `ClientBusyLock`**, causing concurrent requests on the single TCP connection which corrupts the Modbus RTU protocol (strictly request-response, no pipelining)

### Root cause analysis

1. `async_setup_entry()` creates a `Hub` → `BydBoxClient` → `AsyncModbusTcpClient`
2. `hub.init_data()` opens the TCP connection and reads battery info
3. If any read fails, `bydboxclient.init_data()` raises an exception
4. The exception propagates up but **`hub.close()` is never called**
5. The pymodbus TCP socket remains open, occupying the battery's single connection slot
6. HA retries setup → new Hub tries to connect → battery rejects (slot occupied) → permanent failure loop

The `ConnectionHealthMonitor` compounds this by making uncoordinated reads that can interleave with normal data updates, corrupting responses.
