### PR TITLE
Add pymodbus 3.13.x compatibility for unpack_bitstring import

### DIFF
--- a/custom_components/byd_battery_box/extmodbusclient.py
+++ b/custom_components/byd_battery_box/extmodbusclient.py
@@ -2,24 +2,28 @@
 
 """Extended Modbus Class"""
 
-import asyncio
 import logging
 import operator
-import struct
 from typing import Literal
+import struct
+import asyncio
 
 from pymodbus.client import AsyncModbusTcpClient
-
 try:
-    # For newer pymodbus versions (3.9.x+)
-    from pymodbus.pdu.pdu import unpack_bitstring
+    # For pymodbus 3.13.x+
+    from pymodbus.pdu.utils import unpack_bitstring
 except ImportError:
-    # For older pymodbus versions (3.8.x and below)
-    from pymodbus.utilities import unpack_bitstring
-# from  pymodbus.register_write_message import WriteMultipleRegistersResponse
-
+    try:
+        # For pymodbus 3.9.x-3.12.x
+        from pymodbus.pdu.pdu import unpack_bitstring
+    except ImportError:
+        try:
+            # For pymodbus 3.8.x and below
+            from pymodbus.utilities import unpack_bitstring
+        except ImportError as exc:
+            raise ImportError("cannot import unpack_bitstring from pymodbus") from exc
+from pymodbus.exceptions import ModbusIOException, ConnectionException
 from pymodbus import ExceptionResponse
-from pymodbus.exceptions import ConnectionException, ModbusIOException
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/byd_battery_box/extmodbusclient.py
+++ b/custom_components/byd_battery_box/extmodbusclient.py
@@ -2,13 +2,16 @@
 
 """Extended Modbus Class"""
 
+import asyncio
 import logging
 import operator
-from typing import Literal
 import struct
-import asyncio
+from typing import Literal
 
+from pymodbus import ExceptionResponse
 from pymodbus.client import AsyncModbusTcpClient
+from pymodbus.exceptions import ConnectionException, ModbusIOException
+
 try:
     # For pymodbus 3.13.x+
     from pymodbus.pdu.utils import unpack_bitstring
@@ -22,11 +25,8 @@ except ImportError:
             from pymodbus.utilities import unpack_bitstring
         except ImportError as exc:
             raise ImportError("cannot import unpack_bitstring from pymodbus") from exc
-from pymodbus.exceptions import ModbusIOException, ConnectionException
-from pymodbus import ExceptionResponse
 
 _LOGGER = logging.getLogger(__name__)
-
 
 class ExtModbusClient:
     busy = False


### PR DESCRIPTION
## Problem
Integration setup fails on newer pymodbus releases with:
```
ImportError: cannot import name 'unpack_bitstring'
```

`unpack_bitstring` has moved locations across pymodbus versions:
- 3.8.x and below: `pymodbus.utilities`
- 3.9.x–3.12.x: `pymodbus.pdu.pdu`
- 3.13.x+: `pymodbus.pdu.utils`

The existing two-level fallback missed the 3.13.x location.

## Fix
Extended the import fallback chain to try all three known locations in order (newest first). If none succeed, raise a clear `ImportError` explaining the cause, instead of failing silently or using an unverified local reimplementation.

## Testing
Verified integration loads correctly across pymodbus 3.8.x, 3.9–3.12.x, and 3.13.x.