### PR TITLE
Raise ConfigEntryNotReady on transient connect failure (fixes #14)

### DIFF
--- a/custom_components/byd_battery_box/__init__.py
+++ b/custom_components/byd_battery_box/__init__.py
@@ -7,6 +7,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from . import hub
 from .const import CONF_BMS_SCAN_INTERVAL, CONF_LOG_SCAN_INTERVAL, CONF_UNIT_ID, DOMAIN
@@ -38,9 +39,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
 
     try:
         await entry.runtime_data.init_data()
-    except Exception:
+    except Exception as err:
+        # The client raises plain Exception for all connectivity failures during
+        # init, so a broad catch is needed to get automatic setup retries.
         await entry.runtime_data.close()
-        raise
+        raise ConfigEntryNotReady(
+            f"Unable to initialize BYD Battery Box at {host}:{port}: {err}"
+        ) from err
 
     # This creates each HA object for each platform your device requires.
     # It's done by calling the `async_setup_entry` function in each platform module.


### PR DESCRIPTION
## Summary

On the very first setup of a config entry, a transient Modbus connect failure currently leaves the entry in state `setup_error`. Home Assistant does not retry entries in that state, so the integration stays broken until HA is restarted manually. This PR makes `async_setup_entry` raise `ConfigEntryNotReady` instead, so HA automatically retries the setup with its built-in backoff.

Fixes #14.

## Root cause

- `ExtModbusClient.connect()` gives up after 3 attempts with 0.2 s spacing and raises a bare `Exception` (`extmodbusclient.py`). On slow-to-respond devices or a briefly unavailable network, the very first setup can hit this window.
- `async_setup_entry` re-raised that raw exception (`except Exception: ... raise`). Home Assistant only schedules an automatic setup retry when `ConfigEntryNotReady` is raised; any other exception puts the entry into `setup_error` with no retry. This matches the observed behavior in #14: the entry ends up in `setup_error`, not `setup_retry`.

## Fix

Wrap the `init_data()` failure in `ConfigEntryNotReady` (with `raise ... from err` to preserve the original traceback), keeping the existing cleanup via `entry.runtime_data.close()`:

```python
    try:
        await entry.runtime_data.init_data()
    except Exception as err:
        # The client raises plain Exception for all connectivity failures during
        # init, so a broad catch is needed to get automatic setup retries.
        await entry.runtime_data.close()
        raise ConfigEntryNotReady(
            f"Unable to initialize BYD Battery Box at {host}:{port}: {err}"
        ) from err
```

The broad `except Exception` is intentional: the client raises bare `Exception` for every connectivity failure during init (connect failure in `extmodbusclient.py`, base/ext info read failures in `bydboxclient.py`), so there is no specific exception type to catch without refactoring the client's exception hierarchy. Transient read failures right after a successful connect benefit from the retry just as much as connect failures. The original error text is included in the `ConfigEntryNotReady` message, so the failure reason remains visible in the UI and the log.

I also considered widening the retry window inside `connect()` itself, but left it untouched: with the entry-level retry and HA's exponential backoff in place, that is no longer necessary, and it keeps this change minimal.

Two known limitations, both pre-existing and out of scope here: `update_info_data()` / `update_ext_info_data()` can also return `False` instead of raising, and `init_data()` currently ignores those return values, so that failure path still completes setup as before. And because the client flattens everything into plain `Exception`, permanent problems (e.g. a too-old pymodbus) now also land in `setup_retry` instead of `setup_error`; separating those cleanly would need a dedicated exception hierarchy in the client, which would be a good follow-up refactor.

## Testing

- `ruff check custom_components/` and `python -m py_compile custom_components/byd_battery_box/*.py` pass (same checks as CI).
- No physical battery was available to me for an end-to-end test of this exact patch. The live symptom was reproduced and verified by the reporter in #14 (HA core-2026.7.2, pymodbus 3.13.1, integration 0.1.34, BYD HVS via Modbus TCP port 8080): first-time setup fails into `setup_error`, and the current workaround is a manual HA restart.
- Expected behavior after this patch: if the device is unreachable during setup, the entry goes to `setup_retry` ("Cannot connect to BYD Battery Box at host:port: ..."), and HA keeps retrying with backoff until the device responds; once reachable, setup completes without a restart.
