### PR TITLE
Fix swapped cells_per_module and temperature_sensors_per_module

### DIFF
--- a/custom_components/byd_battery_box/bydboxclient.py
+++ b/custom_components/byd_battery_box/bydboxclient.py
@@ -439,8 +439,8 @@ class BydBoxClient(ExtModbusClient):
         self.data['inverter'] = self._get_inverter_model(model, inverter_id)
         self.data['model'] = model
         self.data['capacity'] = capacity
-        self.data['sensors_t'] = self._cells
-        self.data['cells'] = self._temps
+        self.data['sensors_t'] = self._temps
+        self.data['cells'] = self._cells
 
         return True
 


### PR DESCRIPTION
Fixes #16

## Problem

`bydboxclient.py` reads the module spec correctly into the internal fields:

```python
self._cells = specs['cells']        # 32 on HVS - correct
self._temps = specs['sensors_t']    # 12 on HVS - correct
```

but then publishes them crossed:

```python
self.data['sensors_t'] = self._cells    # publishes the cell count as the sensor count
self.data['cells'] = self._temps        # publishes the sensor count as the cell count
```

So `cells_per_module` and `temperature_sensors_per_module` each report the
other value. On a Battery-Box Premium HVS the integration shows 12 cells /
32 temperature sensors per module, while `MODULE_SPECS` and the hardware
have 32 cells / 12 sensors.

Display-only: the per-module parsing loops use the internal `self._cells` /
`self._temps`, which are correct. That is why `cell_voltages` (5 x 32) and
`cell_temps` (5 x 12) are already right.

## Fix

Swap the two assignments so the published values match `MODULE_SPECS`.

## Verification

Tested on HVS 12.8 (5 modules, 1 tower, BMU 3.26 / BMS 3.31), HA core-2026.7.2.
After the change and a restart:

```
cells_per_module:               32   (was 12)
temperature_sensors_per_module: 12   (was 32)
```

All other values unchanged (cell_voltages 5x32 = 160, cell_temps 5x12,
capacity 12.8 kWh, connection healthy).

Independent cross-check that 32 is correct, using no attribute data:
battery_voltage 532.9 V / cells_average_voltage 3.33 V = 160.0 cells in
series; 160 / 5 modules = 32. Capacity math agrees: 2.56 kWh / (32 x 3.2 V)
= 25.0 Ah per cell.